### PR TITLE
push conceal level to window instead of buffer

### DIFF
--- a/lua/ollama-chat/chat.lua
+++ b/lua/ollama-chat/chat.lua
@@ -116,7 +116,7 @@ M.setup_chat_buffer = function()
   M.winnr = vim.api.nvim_get_current_win()
   vim.b.ollama_chat = true
   vim.api.nvim_set_option_value("filetype", "markdown", { buf = M.bufnr })
-  vim.api.nvim_set_option_value("conceallevel", 1, { buf = M.bufnr })
+  vim.api.nvim_set_option_value("conceallevel", 1, { win = M.winnr })
   vim.api.nvim_set_option_value("wrap", true, { win = M.winnr })
   vim.api.nvim_set_option_value("linebreak", true, { win = M.winnr })
 


### PR DESCRIPTION
This was used to resolve the following error when calling the OllamaChat or CreateChat command :  'buf' cannot be passed for window-local option 'conceallevel'

I'm not sure if this is because I'm using a beta version of nvim : 
nvim --version
NVIM v0.10.0-dev
Build type: RelWithDebInfo
LuaJIT 2.1.0-beta3

